### PR TITLE
Pointing README at the license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ We ❤️ contributions from everyone! [Bug reports](https://github.com/Nexmo/ph
 
 ## License
 
-This projet is under the [MIT License](LICENSE)
+This projet is under the [MIT License](LICENSE.md)


### PR DESCRIPTION
README doesn't have the file extension for the license file so it 404's when you click on it. Adding the .md to the end of the license file